### PR TITLE
[민기범] emoji 전처리 및 study-emoji api 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@prisma/client": "^6.15.0",
                 "cors": "^2.8.5",
                 "dotenv": "^16.3.1",
+                "emoji-datasource": "^15.0.1",
                 "express": "^4.18.2",
                 "helmet": "^7.0.0",
                 "morgan": "^1.10.0",
@@ -1524,6 +1525,12 @@
                 "@standard-schema/spec": "^1.0.0",
                 "fast-check": "^3.23.1"
             }
+        },
+        "node_modules/emoji-datasource": {
+            "version": "15.1.2",
+            "resolved": "https://registry.npmjs.org/emoji-datasource/-/emoji-datasource-15.1.2.tgz",
+            "integrity": "sha512-tXAqGsrDVhgCRpFePtaD9P4Z8Ro2SUQSL/4MIJBG0SxqQJaMslEbin8J53OaFwEBu6e7JxFaIF6s4mw9+8acAQ==",
+            "license": "MIT"
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "prisma:generate": "prisma generate",
         "prisma:migrate": "prisma migrate dev",
         "prisma:deploy": "prisma migrate deploy",
-        "prisma:check": "node scripts/check-prisma.js"
+        "prisma:check": "node scripts/check-prisma.js",
+        "emojis:import": "node scripts/import-emojis.js node_modules/emoji-datasource/emoji.json"
     },
     "keywords": [
         "express",
@@ -25,6 +26,7 @@
     "license": "ISC",
     "dependencies": {
         "@prisma/client": "^6.15.0",
+        "emoji-datasource": "^15.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",

--- a/prisma/migrations/20250828082947_test/migration.sql
+++ b/prisma/migrations/20250828082947_test/migration.sql
@@ -1,5 +1,5 @@
--- DropTable
-DROP TABLE "public"."STUDY";
+-- DropTable (guarded)
+DROP TABLE IF EXISTS "public"."STUDY";
 
 -- CreateTable
 CREATE TABLE "public"."studies" (

--- a/prisma/migrations/20250904081614_emoji_id_to_unified/migration.sql
+++ b/prisma/migrations/20250904081614_emoji_id_to_unified/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - The primary key for the `emojis` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."study_emoji" DROP CONSTRAINT "study_emoji_emoji_id_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."emojis" DROP CONSTRAINT "emojis_pkey",
+ALTER COLUMN "emoji_id" DROP DEFAULT,
+ALTER COLUMN "emoji_id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "emojis_pkey" PRIMARY KEY ("emoji_id");
+DROP SEQUENCE "emojis_emoji_id_seq";
+
+-- AlterTable
+ALTER TABLE "public"."study_emoji" ALTER COLUMN "emoji_id" SET DATA TYPE TEXT;
+
+-- AddForeignKey
+ALTER TABLE "public"."study_emoji" ADD CONSTRAINT "study_emoji_emoji_id_fkey" FOREIGN KEY ("emoji_id") REFERENCES "public"."emojis"("emoji_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,8 +73,8 @@ model FocusSession {
 }
 
 model Emoji {
-    id        Int      @id @default(autoincrement()) @map("emoji_id")
-    emoji     String
+    id        String   @id @map("emoji_id") // unified 값을 그대로 저장
+    emoji     String    // 실제 이모지 문자
     createdAt DateTime @default(now()) @map("created_at")
 
     studyEmojis StudyEmoji[] // 1:N
@@ -85,7 +85,7 @@ model Emoji {
 model StudyEmoji {
     id        Int      @id @default(autoincrement()) @map("study_emoji_id")
     studyId   Int      @map("study_id")
-    emojiId   Int      @map("emoji_id")
+    emojiId   String   @map("emoji_id")
     count     Int      @default(0)
     createdAt DateTime @default(now()) @map("created_at")
     updatedAt DateTime @updatedAt @map("updated_at")

--- a/scripts/import-emojis.js
+++ b/scripts/import-emojis.js
@@ -1,0 +1,80 @@
+// Import emojis from emoji-datasource JSON into Prisma DB
+// Usage: node scripts/import-emojis.js <path-to-emoji.json>
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { prisma } from '../src/lib/prisma.js';
+
+function toEmojiFromUnified(unified) {
+    if (!unified || typeof unified !== 'string') return '';
+    try {
+        const codePoints = unified
+            .split('-')
+            .filter(Boolean)
+            .map((h) => parseInt(h, 16));
+        return String.fromCodePoint(...codePoints);
+    } catch {
+        return '';
+    }
+}
+
+async function main() {
+    const [, , jsonPathArg] = process.argv;
+    if (!jsonPathArg) {
+        console.error('Provide path to emoji JSON from emoji-datasource');
+        process.exit(1);
+    }
+    const resolved = path.resolve(jsonPathArg);
+    const raw = await fs.readFile(resolved, 'utf-8');
+    const data = JSON.parse(raw);
+
+    // Expect either array of objects with unified field, or nested by groups
+    let rows = [];
+    if (Array.isArray(data)) {
+        rows = data;
+    } else if (data && typeof data === 'object') {
+        // try common structures: { emojis: [...] } or { data: [...] }
+        rows = Array.isArray(data.emojis) ? data.emojis : Array.isArray(data.data) ? data.data : [];
+    }
+
+    const mapped = rows
+        .map((e) => {
+            const unified = (e.unified || e.unicode || e.id || '').toString().toUpperCase();
+            const emoji = e.emoji || toEmojiFromUnified(unified);
+            if (!unified || !emoji) return null;
+            return { id: unified, emoji };
+        })
+        .filter(Boolean);
+
+    const uniqueMap = new Map();
+    for (const r of mapped) {
+        if (!uniqueMap.has(r.id)) uniqueMap.set(r.id, r);
+    }
+    const list = Array.from(uniqueMap.values());
+    if (list.length === 0) {
+        console.log('No valid emoji rows.');
+        return;
+    }
+
+    console.log(`Preparing to insert ${list.length} emojis...`);
+
+    // chunked insert to avoid parameter limits
+    const chunkSize = 1000;
+    let inserted = 0;
+    for (let i = 0; i < list.length; i += chunkSize) {
+        const chunk = list.slice(i, i + chunkSize);
+        const res = await prisma.emoji.createMany({ data: chunk, skipDuplicates: true });
+        inserted += res.count || 0;
+    }
+
+    console.log(`Done. Inserted ${inserted} new emojis.`);
+}
+
+main()
+    .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });

--- a/src/routes/emojis.js
+++ b/src/routes/emojis.js
@@ -4,64 +4,6 @@ import { parseId } from '../lib/utils.js';
 
 const router = express.Router();
 
-// POST /emojis - 외부 API(https://www.emoji.family/api/emojis)에서 가져와 동기화
-router.post('/emojis', async (_req, res, next) => {
-    try {
-        const endpoint = 'https://www.emoji.family/api/emojis';
-
-        const resp = await fetch(endpoint, { method: 'GET' });
-        if (!resp.ok) {
-            return res.status(502).json({ error: `Upstream error: ${resp.status}` });
-        }
-        const data = await resp.json();
-
-        // emoji family의 포맷을 입력받아서 DB엔 emoji 문자열(이모티콘)만 저장
-        let list = [];
-        if (Array.isArray(data)) {
-            if (data.length > 0 && typeof data[0] === 'string') {
-                list = data;
-            } else if (data.length > 0 && typeof data[0] === 'object') {
-                list = data
-                    .map((d) => (d && typeof d.emoji === 'string' ? d.emoji : null))
-                    .filter((v) => typeof v === 'string' && v.trim().length > 0);
-            }
-        }
-
-        // 정제 및 중복 제거
-        list = list.map((e) => e.trim()).filter((e) => e.length > 0);
-        const unique = Array.from(new Set(list));
-
-        if (unique.length === 0) {
-            return res.status(200).json({ inserted: 0, totalFetched: 0, skipped: 0, items: [] });
-        }
-
-        // 이미 존재하는 이모지 조회 (중복 삽입 방지)
-        const existing = await prisma.emoji.findMany({
-            where: { emoji: { in: unique } },
-            select: { emoji: true },
-        });
-        const existingSet = new Set(existing.map((e) => e.emoji));
-        const toInsert = unique.filter((e) => !existingSet.has(e));
-
-        let inserted = 0;
-        if (toInsert.length > 0) {
-            // createMany 사용 (주의: unique 제약이 없으므로 사전 필터로 방지)
-            const result = await prisma.emoji.createMany({
-                data: toInsert.map((e) => ({ emoji: e })),
-            });
-            inserted = result.count || 0;
-        }
-
-        return res.status(201).json({
-            inserted,
-            totalFetched: unique.length,
-            skipped: unique.length - inserted,
-        });
-    } catch (err) {
-        next(err);
-    }
-});
-
 // GET /emojis - 목록 조회
 router.get('/emojis', async (req, res, next) => {
     try {
@@ -104,7 +46,7 @@ router.get('/emojis', async (req, res, next) => {
 // GET /emojis/:id - 상세 조회
 router.get('/emojis/:id', async (req, res, next) => {
     try {
-        const id = parseId(req.params.id);
+        const id = (req.params.id || '').trim();
         if (!id)
             return res.status(400).json({
                 error: 'Invalid id',
@@ -145,7 +87,7 @@ router.get('/emojis/:id', async (req, res, next) => {
 router.post('/studies/:studyId/emojis/:emojiId', async (req, res, next) => {
     try {
         const studyId = parseId(req.params.studyId);
-        const emojiId = parseId(req.params.emojiId);
+        const emojiId = (req.params.emojiId || '').trim();
         if (!studyId || !emojiId) {
             return res.status(400).json({
                 error: 'Invalid studyId or emojiId',


### PR DESCRIPTION
- emoji-datasource를 이용해 emoji-picker-react에 사용할 emoji를 db에 전처리하여 저장
  - emoji POST 삭제(이미 전처리로 데이터를 전부 저장)
- emoji id를 string으로 된 unified 값을 사용하도록 변경
  - study_id와 emoji_id만을 이용해 연결하도록 설정